### PR TITLE
Fix syntax errors in rex_keys.erb

### DIFF
--- a/templates/rex_keys.erb
+++ b/templates/rex_keys.erb
@@ -2,4 +2,4 @@
 
 <% @rex_keys.each do |key| -%>
 <%= key %>
-<$ end -%>
+<% end -%>


### PR DESCRIPTION
Template failed to resolve correctly due to $ instead of %